### PR TITLE
Add relative path support

### DIFF
--- a/clone-org.go
+++ b/clone-org.go
@@ -5,6 +5,7 @@ package cloneorg
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -66,4 +67,25 @@ func findRepos(ctx context.Context, client *github.Client, org string) (result [
 		opt.ListOptions.Page = resp.NextPage
 	}
 	return result, nil
+}
+
+// CreateDir creates the directory if it does not exists
+func CreateDir(directory string) error {
+	stat, err := os.Stat(directory)
+	directoryDoesNotExists := err != nil
+
+	if directoryDoesNotExists {
+		err := os.MkdirAll(directory, 0700)
+		if err != nil {
+			return fmt.Errorf("couldn't create directory: %v", err)
+		}
+
+		return nil
+	}
+
+	if stat.IsDir() {
+		return nil
+	}
+
+	return fmt.Errorf("directory provided is a file: %v", directory)
 }

--- a/cmd/clone-org/main.go
+++ b/cmd/clone-org/main.go
@@ -32,20 +32,23 @@ func main() {
 		},
 	}
 	app.Action = func(c *cli.Context) error {
-		var token = c.String("token")
-		var org = c.String("org")
+		token := c.String("token")
 		if token == "" {
 			return cli.NewExitError("missing github token", 1)
 		}
+
+		org := c.String("org")
 		if org == "" {
 			return cli.NewExitError("missing organization name", 1)
 		}
+
 		destination := c.String("destination")
 		if destination == "" {
 			destination = filepath.Join(os.TempDir(), org)
 		}
 		fmt.Printf("Destination: %v\n", destination)
-		var s = spin.New("%s Finding repositories to clone...")
+
+		s := spin.New("%s Finding repositories to clone...")
 		s.Start()
 		repos, err := cloneorg.AllOrgRepos(token, org)
 		s.Stop()

--- a/cmd/clone-org/main.go
+++ b/cmd/clone-org/main.go
@@ -56,7 +56,7 @@ func main() {
 			return cli.NewExitError(err.Error(), 1)
 		}
 
-		if err := os.Mkdir(destination, 0700); err != nil {
+		if err := cloneorg.CreateDir(destination); err != nil {
 			return cli.NewExitError(err.Error(), 1)
 		}
 


### PR DESCRIPTION
Allow the user to provide any relative or full path.

Examples:

```bash
clone-org -o org -d .
clone-org -o org -d ../
clone-org -o org -d something/../directory
clone-org -o org -d /some/directory
```