### PR TITLE
Display one message per repo, of either success or error

### DIFF
--- a/cmd/clone-org/main.go
+++ b/cmd/clone-org/main.go
@@ -60,16 +60,18 @@ func main() {
 			return cli.NewExitError(err.Error(), 1)
 		}
 
-		s = spin.New(fmt.Sprintf(
-			"%v Cloning %v repositories...", "%v", len(repos),
-		))
-		s.Start()
-		defer s.Stop()
+		fmt.Printf("Cloning %v repositories:\n", len(repos))
 		var g errgroup.Group
 		for _, repo := range repos {
 			repo := repo
 			g.Go(func() error {
-				return cloneorg.Clone(repo, destination)
+				err := cloneorg.Clone(repo, destination)
+				if err != nil {
+					fmt.Printf("\033[33m[failed] %s\033[0m: %s", repo.Name, err)
+				} else {
+					fmt.Printf("\033[32m[cloned] %s\033[0m\n", repo.Name)
+				}
+				return nil
 			})
 		}
 		return g.Wait()


### PR DESCRIPTION
Before, only the first error message received from a goroutine was being shown, now there is one message per repo of either success or error. It uses green for success and yellow for error.

![screen shot 2018-03-17 at 17 14 15](https://user-images.githubusercontent.com/4459232/37557674-792b4cde-2a08-11e8-8f45-296207a90ea7.png)

---

What we talked about on #7 of cloning only new repos was already working, but the message that was being shown was incomplete. That's the reason of this change, what do you think?